### PR TITLE
Memory management improvements for scheduler

### DIFF
--- a/tpf/QueuesContainer.h
+++ b/tpf/QueuesContainer.h
@@ -4,7 +4,13 @@
 
 namespace Parallel {
 	struct QueuesContainer {
-		ConcurrentQueue<Task*>* InternalQueue;
-		ConcurrentQueue<Task*>* ExternalQueue;
+		ConcurrentQueue<Task*> InternalQueue;
+		ConcurrentQueue<Task*> ExternalQueue;
+
+		QueuesContainer(int queuesSize)
+			: InternalQueue( queuesSize )
+			, ExternalQueue( queuesSize )
+		{
+		}
 	};
 }

--- a/tpf/Scheduler.cpp
+++ b/tpf/Scheduler.cpp
@@ -14,6 +14,9 @@ Scheduler::Scheduler(int queuesSize)
 	, _ioWorkers(std::vector<IoWorker*>())
 	, _cpuWorkers(std::vector<CpuWorker*>())
 {
+	_queues.reserve( _cores );
+	_cpuWorkers.reserve( _cores );
+
 	for (int i = 0; i < _cores; i++) {
 		QueuesContainer* queues = new QueuesContainer( queuesSize );
 		CpuWorker* worker = new CpuWorker(this, _syncForWorkers);

--- a/tpf/Scheduler.cpp
+++ b/tpf/Scheduler.cpp
@@ -95,15 +95,17 @@ Task* Scheduler::StealTaskFromOtherWorkers(std::function<ConcurrentQueue<Task*>*
 
 void Scheduler::Compute(Task* task) {
 	Task* continuation = nullptr;
+	std::thread::id currentThreadId = std::this_thread::get_id();
+
 	do {
 		if (!task->IsCanceled()) {
-			CurrentTask* current = _currentTasks[std::this_thread::get_id()];
+			CurrentTask* current = _currentTasks[currentThreadId];
 			current->Task = task;
 			current->IsRecyclable = false;
 
 			Task* c = task->Compute();
 
-			if (!_currentTasks[std::this_thread::get_id()]->IsRecyclable && task->PendingCount() == 0) {
+			if (!_currentTasks[currentThreadId]->IsRecyclable && task->PendingCount() == 0) {
 				if (task->Continuation() != nullptr) {
 					continuation = task->Continuation();
 				}


### PR DESCRIPTION
Queues container now have two local task containers that are just inlined types, so they are not pointers. This mean we have two times lower allocations for each thread(only one for now). Another imporement goes for unordered maps in scheduler: now we have memory preserving for these containers, so allocation will be only once per container. This is because we know count of threads on construction.
