### PR TITLE
Refactoring/concurrent queue improvements

### DIFF
--- a/tpf/ConcurrentQueue.h
+++ b/tpf/ConcurrentQueue.h
@@ -1,12 +1,15 @@
 #pragma once
 #include <atomic>
 #include "SpinWait.h"
+#include <assert.h>
 
 namespace Parallel {
 	template<typename T>
 	class ConcurrentQueue {
 	public:
-		ConcurrentQueue(int size) : _size(size), _tail(0), _head(0), _buffer(new AtomicBufferWithIndicator[size]) {
+		ConcurrentQueue(int size) : _size(size), _tail(0), _head(0) {
+			assert( size > 0 );
+			_buffer = new AtomicBufferWithIndicator[size];
 		}
 
 		bool TryEnqueue(T value) {

--- a/tpf/ConcurrentQueue.h
+++ b/tpf/ConcurrentQueue.h
@@ -12,6 +12,10 @@ namespace Parallel {
 			_buffer = new AtomicBufferWithIndicator[size];
 		}
 
+		~ConcurrentQueue() {
+			delete[] _buffer;
+		}
+
 		bool TryEnqueue(T value) {
 			SpinWait spinWait;
 			while (true) {

--- a/tpf/ConcurrentQueue.h
+++ b/tpf/ConcurrentQueue.h
@@ -61,7 +61,7 @@ namespace Parallel {
 		}
 
 	private:
-		__declspec(align(64)) struct AtomicBufferWithIndicator
+		struct AtomicBufferWithIndicator
 		{
 			T value;
 			std::atomic<bool> isCommited;


### PR DESCRIPTION
Current implementation of concurrent queue(or better to say circular buffer) has some downsides. First of all there are two arrays of atomics where the first one is for value and the second one is like "LED" that shows commit state of value. Second one is memory leak on queue destruction.

The first problem is solved by merging value and commit state in one structure. More to say, value is not atomic anymore because it doesn't need such complication when commit state is still an atomic flag. Everything looks like Array Of Structure(AOS) instead of Structure of Arrays(SOA) in concurrent queue template class. Also this improvement requires only one pointer upload operation into cache instead of two when there was SOA. Another few details about structure with value and commit state are that every entry of array can be easily placed into cache line of CPU so this can improve performance on value commit state querying and simultaneous value access. 
